### PR TITLE
fix: 修复 CI LINKS 检查失败

### DIFF
--- a/src/zh/md-enhance-guide.md
+++ b/src/zh/md-enhance-guide.md
@@ -98,7 +98,7 @@ MDC 形式（YAML props 使用 `---` 包裹）：
 logo: self
 title: That normal theme card
 desc: This is description
-cover: https://upload-bbs.miyoushe.com/upload/2024/02/21/292762008/86d3c06e1a1adf7ef432cf838f7abb8c_7693471731342377565.png?x-oss-process=image/resize,s_500/quality,q_80/auto-orient,0/interlace/1,format/jpg
+cover: https://upload-bbs.miyoushe.com/upload/2024/02/21/292762008/86d3c06e1a1adf7ef432cf838f7abb8c_7693471731342377565.png
 ---
 
 ::


### PR DESCRIPTION
## 问题定位

`LINKS`（lychee link checker）工作流自 2026-07 起持续失败，**唯一错误**为：

- `src/zh/md-enhance-guide.md:101` 的米游社图片 URL 返回 **400 Bad Request**

```text
https://upload-bbs.miyoushe.com/upload/2024/02/21/...86d3c06e..._7693471731342377565.png?x-oss-process=image/resize,s_500/quality,q_80/auto-orient,0/interlace/1,format/jpg
```

## 根因确认

- 带 `?x-oss-process=...` 处理参数：**400**（米游社 OSS 拒绝该处理参数链）
- 裸链接（去掉 query）：**200** ✅（图片本体仍存在）

仓库中该 URL 仅此一处引用，其他 locale 无对应文件。

## 修复方案

移除失效的 `x-oss-process` query 参数，使用原始图片链接（已验证 200）。

## 验证

- 本 PR 的 `LINKS` 检查应通过（重定向输出为 lychee `--verbose` 的信息性内容，不构成错误）
- 后续如再出现失败，可考虑在 `.github/workflows/links.yml` 中对重定向链接补充 `--exclude` 减少噪音（本次未做，避免扩大改动范围）