### PR TITLE
ci: 接入 lunaria-claim 翻译认领看板（灰度）

### DIFF
--- a/.github/lunaria-claim.md
+++ b/.github/lunaria-claim.md
@@ -1,0 +1,19 @@
+## 🙋 翻译认领
+
+本清单由 [lunaria-claim](https://github.com/jiazengp/lunaria-claim) 基于 Lunaria 的 status.json 自动维护。
+
+认领方式：在下方清单里挑一个文件（或整个目录），评论 `/claim 文件路径` 即可认领，可一次认领多个。认领后请在 **{{ttl_days}}** 天内提交 PR，逾期自动释放，届时欢迎重新认领。
+
+- 开始翻译前请先阅读[翻译贡献指南](https://github.com/kongying-tavern/docs/blob/main/.github/translation-guide.md)
+- 想启动新语言？见[启动新语言翻译教程](https://github.com/kongying-tavern/docs/blob/main/.github/trans-guide-new-language.md)
+- [翻译进度总览](https://yuanshen.site/docs/_translations/)（Lunaria 仪表盘）
+
+<!-- LUNARIA-CLAIM:FILES -->
+{{files}}
+<!-- /LUNARIA-CLAIM:FILES -->
+
+<!-- LUNARIA-CLAIM:STATE v1 -->
+{}
+<!-- /LUNARIA-CLAIM:STATE -->
+
+> 标记区内的内容由 lunaria-claim 自动维护，请勿编辑。

--- a/.github/lunaria-claim.yml
+++ b/.github/lunaria-claim.yml
@@ -1,0 +1,8 @@
+# lunaria-claim 认领看板配置
+issue:
+  title: '🙋 文档翻译认领'
+  # 灰度阶段用 test label，验收后改为 lunaria-claim 再重新 sync
+  label: 'lunaria-claim-test'
+ttlDays: 15                # 与既有「15 天内提交 PR」规则一致
+collapseThreshold: 30      # 单语言区块超过 30 条折叠
+# fileListStyle: tree      # 清单按目录树展示（默认）

--- a/.github/workflows/claim-bot.yml
+++ b/.github/workflows/claim-bot.yml
@@ -1,0 +1,49 @@
+# 认领交互：评论认领 / PR 关联 / 每日超期清扫，三个 job 按事件自动路由；手动运行 = 立即清扫
+name: Translation claim bot
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, synchronize, closed]
+  schedule:
+    - cron: '0 21 * * *' # 每天 UTC 21:00；过期判定基于认领时间戳，触发延迟不影响正确性
+  workflow_dispatch:
+
+# 所有 bot 写操作经同一并发队列串行，防止 read-modify-write 互相覆盖
+concurrency:
+  group: lunaria-claim
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  claim:
+    if: github.event_name == 'issue_comment' && !github.event.issue.pull_request
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: jiazengp/lunaria-claim@v1
+        with:
+          mode: claim
+
+  link-pr:
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    steps:
+      # 只用 API 读取配置与 PR 文件列表，不 checkout 不可信代码
+      - uses: actions/checkout@v7
+      - uses: jiazengp/lunaria-claim@v1
+        with:
+          mode: link-pr
+
+  expire:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: jiazengp/lunaria-claim@v1
+        with:
+          mode: expire

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,34 @@
+name: Translation tracker sync
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: lunaria-claim-sync
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0 # Lunaria 需要完整 git 历史
+      - uses: pnpm/action-setup@v6
+        with:
+          run_install: false
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+      - run: pnpm install
+      - run: pnpm lunaria:build
+      - uses: jiazengp/lunaria-claim@v1
+        with:
+          mode: sync
+          # 与 lunaria.config.json 的 outDir 对应
+          status-json: ./dist/_translations/status.json


### PR DESCRIPTION
## 变更内容

接入 [lunaria-claim](https://github.com/jiazengp/lunaria-claim) 翻译认领看板（基于 Lunaria status.json + GitHub Issue），共 4 个文件：

| 文件 | 作用 |
| --- | --- |
| `.github/workflows/sync.yml` | push 到 main 后跑 `pnpm lunaria:build` → 创建/对账认领 issue（也支持手动运行） |
| `.github/workflows/claim-bot.yml` | 评论认领 / PR 自动关联与关闭释放 / 每日 UTC 21:00 超期清扫，三合一 |
| `.github/lunaria-claim.yml` | 看板配置：TTL 15 天（与既有规则一致）、单语言超 30 条折叠、**灰度 label `lunaria-claim-test`** |
| `.github/lunaria-claim.md` | 认领 issue 正文模板（含翻译指南与进度页链接） |

## 灰度与验收流程

1. 合并本 PR 后，**手动运行一次 `Translation tracker sync`**——会创建一个带 `lunaria-claim-test` 标签的认领 issue（清单来自 `dist/_translations/status.json`，树状展示，按语言分区）；
2. 验收清单：评论 `/claim 路径` 认领（有 🚀 与标注）→ 勾选已认领后取消勾选（会按手动释放处理）→ 提交含认领文件的 PR（自动关联、冻结超期）→ 超期自动释放；
3. 验收通过后：把 `.github/lunaria-claim.yml` 的 `issue.label` 改为 `lunaria-claim`，重新手动 sync 建正式认领 issue，原 #242 归档（规则文字可从模板复用）。

## 备注

- sync 每次 push 到 main 会多跑约几分钟（pnpm install + lunaria build），频率可后续用 paths 过滤；
- 认领 issue 的 URL 可通过 sync 的 `issue-url` 输出引用（如 `translations.md` 页面）；
- 当前引用 `jiazengp/lunaria-claim@v1`（1.0.0）；1.1.0 将含状态块损坏自愈重建、dry-run 预览等能力，无需改动本仓库配置即可获得。
