### PR TITLE
fix(theme): scan src js/ts in the UnoCSS pipeline so icon classes resolve

### DIFF
--- a/unocss.config.ts
+++ b/unocss.config.ts
@@ -129,8 +129,11 @@ export default defineConfig({
       include: [
         // the default
         /\.(vue|svelte|[jt]sx|mdx?|astro|elm|php|phtml|html)($|\?)/,
-        // include js/ts files
-        'src/**/*.{js,ts}',
+        // include js/ts files under src/. Patterns are resolved against the Vite
+        // root, which VitePress sets to srcDir, and any pattern starting with
+        // "**" skips that resolution and matches the whole filesystem, so this
+        // has to be anchored with a regex.
+        /\/src\/[^?]*\.(js|ts)$/,
       ],
     },
   },


### PR DESCRIPTION
## Summary

The Google Drive entry on `/download-client` rendered with a blank icon: the element got `class="i-logos-google-drive"` but no matching CSS rule was ever generated.

Root cause: the `content.pipeline.include` glob `src/**/*.{js,ts}` was resolved against the Vite root, which VitePress sets to `srcDir` (`src/`), so it expanded to `src/src/**/*.{js,ts}` and matched no real file. Class names authored only in `src/**/*.ts` were therefore never extracted. `i-logos-google-drive` is written only in `src/components/links/Download.ts` (it moved there from the `.md` `<script setup>` in 7706891e), so it silently lost its rule. Every other download entry uses `<img src="...">`, and the remaining `i-logos-*` cases are covered by `safelist`, which is why only this one broke.

## Fix

Anchor the include pattern with a regex so it scans `src/**/*.{js,ts}` under the real Vite root:

```diff
-        // include js/ts files
-        'src/**/*.{js,ts}',
+        // include js/ts files under src/. Patterns are resolved against the Vite
+        // root, which VitePress sets to srcDir, and any pattern starting with
+        // "**" skips that resolution and matches the whole filesystem, so this
+        // has to be anchored with a regex.
+        /\/src\/[^?]*\.(js|ts)$/,
```

A glob starting with `**` (e.g. `**/*.{js,ts}`) must not be used here: `unplugin-utils` skips the resolution base for those, so it ends up matching every `.js`/`.ts` outside `node_modules` — including Vite's prebundled `.vitepress/cache/deps/*.js`. `presetAttributify` then parses that minified code into invalid rules such as `[select~="$event)"]{user-select:var(--event));}`, which makes postcss fail on `/__uno.css` with `Unknown word` and takes down the entire stylesheet.

## Verification

- `pnpm dev`: `.i-logos-google-drive{background:url("data:image/svg+xml;utf8,...")}` is present in `__uno.css`, with no postcss errors and no `[unocss] failed to load icon` noise.
- Browser on `/download-client`: all six entries render, and the Google Drive icon has a 40x40 SVG background.
- `pnpm build` passes in 69.86s with no warnings, and `dist/assets/style.*.css` contains the rule with no invalid CSS.
- `npx eslint unocss.config.ts` is clean.

No data scripts were run.
